### PR TITLE
use overloads for textmap.py

### DIFF
--- a/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py
@@ -29,11 +29,11 @@ class W3CBaggagePropagator(textmap.TextMapPropagator):
     _MAX_PAIRS = 180
     _BAGGAGE_HEADER_NAME = "baggage"
 
-    def extract(
+    def _extract(
         self,
         carrier: textmap.CarrierT,
+        getter: textmap.Getter[textmap.CarrierT],
         context: typing.Optional[Context] = None,
-        getter: textmap.Getter = textmap.default_getter,
     ) -> Context:
         """Extract Baggage from the carrier.
 
@@ -71,11 +71,11 @@ class W3CBaggagePropagator(textmap.TextMapPropagator):
 
         return context
 
-    def inject(
+    def _inject(
         self,
         carrier: textmap.CarrierT,
+        setter: textmap.Setter[textmap.CarrierT],
         context: typing.Optional[Context] = None,
-        setter: textmap.Setter = textmap.default_setter,
     ) -> None:
         """Injects Baggage into the carrier.
 

--- a/opentelemetry-api/src/opentelemetry/propagate/__init__.py
+++ b/opentelemetry-api/src/opentelemetry/propagate/__init__.py
@@ -81,10 +81,30 @@ from opentelemetry.propagators import composite, textmap
 logger = getLogger(__name__)
 
 
+@typing.overload
 def extract(
     carrier: textmap.CarrierT,
+    getter: textmap.DefaultGetter = textmap.default_getter,
     context: typing.Optional[Context] = None,
-    getter: textmap.Getter = textmap.default_getter,
+) -> Context:
+    ...
+
+
+@typing.overload
+def extract(
+    carrier: textmap.CarrierT,
+    getter: textmap.Getter[textmap.CarrierT],
+    context: typing.Optional[Context] = None,
+) -> Context:
+    ...
+
+
+def extract(
+    carrier: textmap.CarrierT,
+    getter: typing.Union[
+        textmap.Getter[textmap.CarrierT], textmap.DefaultGetter
+    ] = textmap.default_getter,
+    context: typing.Optional[Context] = None,
 ) -> Context:
     """Uses the configured propagator to extract a Context from the carrier.
 
@@ -99,13 +119,35 @@ def extract(
         context: an optional Context to use. Defaults to current
             context if not set.
     """
-    return get_global_textmap().extract(carrier, context, getter=getter)
+    return get_global_textmap().extract(  # type: ignore
+        carrier, getter=getter, context=context
+    )
+
+
+@typing.overload
+def inject(
+    carrier: typing.MutableMapping[str, textmap.CarrierValT],
+    setter: textmap.DefaultSetter = textmap.default_setter,
+    context: typing.Optional[Context] = None,
+) -> None:
+    ...
+
+
+@typing.overload
+def inject(
+    carrier: textmap.CarrierT,
+    setter: textmap.Setter[textmap.CarrierT],
+    context: typing.Optional[Context] = None,
+) -> None:
+    ...
 
 
 def inject(
     carrier: textmap.CarrierT,
+    setter: typing.Union[
+        textmap.Setter[textmap.CarrierT], textmap.DefaultSetter
+    ] = textmap.default_setter,
     context: typing.Optional[Context] = None,
-    setter: textmap.Setter = textmap.default_setter,
 ) -> None:
     """Uses the configured propagator to inject a Context into the carrier.
 
@@ -118,7 +160,9 @@ def inject(
         setter: An optional `Setter` object that can set values
             on the carrier.
     """
-    get_global_textmap().inject(carrier, context=context, setter=setter)
+    get_global_textmap().inject(  # type: ignore
+        carrier, setter=setter, context=context,
+    )
 
 
 try:

--- a/opentelemetry-api/src/opentelemetry/propagators/composite.py
+++ b/opentelemetry-api/src/opentelemetry/propagators/composite.py
@@ -33,11 +33,11 @@ class CompositeHTTPPropagator(textmap.TextMapPropagator):
     ) -> None:
         self._propagators = propagators
 
-    def extract(
+    def _extract(
         self,
         carrier: textmap.CarrierT,
+        getter: textmap.Getter[textmap.CarrierT],
         context: typing.Optional[Context] = None,
-        getter: textmap.Getter = textmap.default_getter,
     ) -> Context:
         """Run each of the configured propagators with the given context and carrier.
         Propagators are run in the order they are configured, if multiple
@@ -47,14 +47,16 @@ class CompositeHTTPPropagator(textmap.TextMapPropagator):
         See `opentelemetry.propagators.textmap.TextMapPropagator.extract`
         """
         for propagator in self._propagators:
-            context = propagator.extract(carrier, context, getter=getter)
+            context = propagator.extract(
+                carrier, getter=getter, context=context
+            )
         return context  # type: ignore
 
-    def inject(
+    def _inject(
         self,
         carrier: textmap.CarrierT,
+        setter: textmap.Setter[textmap.CarrierT],
         context: typing.Optional[Context] = None,
-        setter: textmap.Setter = textmap.default_setter,
     ) -> None:
         """Run each of the configured propagators with the given context and carrier.
         Propagators are run in the order they are configured, if multiple
@@ -64,7 +66,7 @@ class CompositeHTTPPropagator(textmap.TextMapPropagator):
         See `opentelemetry.propagators.textmap.TextMapPropagator.inject`
         """
         for propagator in self._propagators:
-            propagator.inject(carrier, context, setter=setter)
+            propagator.inject(carrier, setter=setter, context=context)
 
     @property
     def fields(self) -> typing.Set[str]:

--- a/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
+++ b/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py
@@ -33,11 +33,11 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
     )
     _TRACEPARENT_HEADER_FORMAT_RE = re.compile(_TRACEPARENT_HEADER_FORMAT)
 
-    def extract(
+    def _extract(
         self,
         carrier: textmap.CarrierT,
+        getter: textmap.Getter[textmap.CarrierT],
         context: typing.Optional[Context] = None,
-        getter: textmap.Getter = textmap.default_getter,
     ) -> Context:
         """Extracts SpanContext from the carrier.
 
@@ -83,11 +83,11 @@ class TraceContextTextMapPropagator(textmap.TextMapPropagator):
             trace.NonRecordingSpan(span_context), context
         )
 
-    def inject(
+    def _inject(
         self,
         carrier: textmap.CarrierT,
+        setter: textmap.Setter[textmap.CarrierT],
         context: typing.Optional[Context] = None,
-        setter: textmap.Setter = textmap.default_setter,
     ) -> None:
         """Injects SpanContext into the carrier.
 

--- a/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
+++ b/propagator/opentelemetry-propagator-jaeger/src/opentelemetry/propagators/jaeger/__init__.py
@@ -23,8 +23,6 @@ from opentelemetry.propagators.textmap import (
     Getter,
     Setter,
     TextMapPropagator,
-    default_getter,
-    default_setter,
 )
 from opentelemetry.trace import format_span_id, format_trace_id
 
@@ -39,11 +37,11 @@ class JaegerPropagator(TextMapPropagator):
     BAGGAGE_PREFIX = "uberctx-"
     DEBUG_FLAG = 0x02
 
-    def extract(
+    def _extract(
         self,
         carrier: CarrierT,
+        getter: Getter[CarrierT],
         context: typing.Optional[Context] = None,
-        getter: Getter = default_getter,
     ) -> Context:
 
         if context is None:
@@ -76,11 +74,11 @@ class JaegerPropagator(TextMapPropagator):
         )
         return trace.set_span_in_context(span, context)
 
-    def inject(
+    def _inject(
         self,
         carrier: CarrierT,
+        setter: Setter[CarrierT],
         context: typing.Optional[Context] = None,
-        setter: Setter = default_setter,
     ) -> None:
         span = trace.get_current_span(context=context)
         span_context = span.get_span_context()


### PR DESCRIPTION
I basically
- added back the generic to Getter and Setter
- Added the overloads to TextMapPropagator
- made it so propagors implement `_extract()` and `_inject()` , and `TextMapPropagator` calls those with the correct defaults.
I think that fixes the typing issues and makes the interface nice for both callers and implementers of propagators 

The only thing I had to change was the parameter order, so its now `extract(carrier, getter, context)`